### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,6 @@
 name: 🔬 Pull Request Checks
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/anthonyhagi/kit-node-sdk/security/code-scanning/7](https://github.com/anthonyhagi/kit-node-sdk/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow only requires read access to the repository contents (e.g., to check out the code), we will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
